### PR TITLE
Make values in flags test more obvious

### DIFF
--- a/src/tests/flags.8o
+++ b/src/tests/flags.8o
@@ -3,8 +3,11 @@
 # This is a visual adaptation of the math tests I wrote for Silicon8
 # (https://github.com/Timendus/silicon8/tree/main/tests)
 
+:alias 15_in_a_register v1
+:alias 100_in_a_register v1
+
 :macro opcode-digit OPC {
-  vD := OPC  
+  vD := OPC
   flags-draw-opcode-digit
 }
 
@@ -68,18 +71,16 @@
   text 0 0 flags-no-carry
   x := 22
   y := 0
-
-  v0 := 50
-  v1 := 15
+  15_in_a_register := 15
 
   # OR
   opcode-digit 1 # 0x81
   v3 := 15
   vF := 20
   v3 |= vF # 31 (0x1F)
-  vF := 0
-  v2 := v0
-  v2 |= v1 # 63 (0x3F)
+  vF := 0 # vF will not be reset if that quirk is not active
+  v2 := 50
+  v2 |= 15_in_a_register # 63 (0x3F)
   expect-v2-vf-v3 63 0 31
   x += 5
 
@@ -88,9 +89,9 @@
   v3 := 15
   vF := 20
   v3 &= vF # 4 (0x04)
-  vF := 0
-  v2 := v0
-  v2 &= v1 # 2 (0x02)
+  vF := 0 # vF will not be reset if that quirk is not active
+  v2 := 50
+  v2 &= 15_in_a_register # 2 (0x02)
   expect-v2-vf-v3 2 0 4
   
   y += 5
@@ -101,35 +102,37 @@
   v3 := 15
   vF := 20
   v3 ^= vF # 27 (0x1B)
-  vF := 0
-  v2 := v0
-  v2 ^= v1 # 61 (0x3D)
+  vF := 0 # vF will not be reset if that quirk is not active
+  v2 := 50
+  v2 ^= 15_in_a_register # 61 (0x3D)
   expect-v2-vf-v3 61 0 27
   x += 5
 
   # Addition (no overflow)
   opcode-digit 0x4 # 0x84
+  vF := 20
+  vF += 15_in_a_register # 35 (0x23), but should be overwritten by flag, so 0
+  v4 := vF
   v3 := 15
   vF := 20
-  vF += v3 # 35 (0x23), but should be overwritten by flag, so 0
-  v4 := vF
-  vF := 20
   v3 += vF # 35 (0x23)
-  v2 := v0
-  v2 += v1 # 65 (0x41)
+  vF := 0xAA
+  v2 := 50
+  v2 += 15_in_a_register # 65 (0x41)
   expect-v2-vf-v3-v4 65 0 35 0
   x += 1
 
   # Subtraction in one direction (no carry)
   opcode-digit 0x5 # 0x85
-  v3 := 20
-  vF := 25
-  vF -= v3 # 5 (0x05), but should be overwritten by flag, so 1
+  vF := 20
+  vF -= 15_in_a_register # 5 (0x05), but should be overwritten by flag, so 1
   v4 := vF
+  v3 := 20
   vF := 15 
   v3 -= vF # 5 (0x05)
-  v2 := v0
-  v2 -= v1 # 35 (0x23)
+  vF := 0xAA
+  v2 := 50
+  v2 -= 15_in_a_register # 35 (0x23)
   expect-v2-vf-v3-v4 35 1 5 1
 
   y += 5
@@ -137,33 +140,37 @@
 
   # Shift right (no LSB)
   opcode-digit 0x6 # 0x86
-  vF := v0
-  vF >>= vF # 25 (0x19), but should be overwritten by flag, so 0
+  vF := 60
+  vF >>= vF # 30 (0x1E), but should be overwritten by flag, so 0
   v3 := vF
-  v2 := v0
-  v2 >>= v2 # 25 (0x19)
-  expect-v2-vf-v3 25 0 0
+  # vF := 0xAA
+  v2 := 60
+  v2 >>= v2 # 30 (0x1E)
+  expect-v2-vf-v3 30 0 0
   x += 5
 
   # Subtraction in the other direction (no carry)
   opcode-digit 0x7 # 0x87
-  v3 := 15
   vF := 10
-  vF =- v3 # 5 (0x5), but should be overwritten by flag, so 1
+  vF =- 15_in_a_register # 5 (0x5), but should be overwritten by flag, so 1
   v4 := vF
+  v3 := 15
   vF := 20
   v3 =- vF # 5 (0x05)
-  v2 := v1
-  v2 =- v0 # 35 (0x23)
+  # vF := 0xAA
+  v2 := 15
+  v1 := 50
+  v2 =- v1 # 35 (0x23)
   expect-v2-vf-v3-v4 35 1 5 1
   x += 1
 
   # Shift left (no MSB)
   opcode-digit 0xE # 0x8E
-  vF := v0
+  vF := 50
   vF <<= vF # 100 (0x64), but should be overwritten by flag, so 0
   v3 := vF
-  v2 := v0
+  # vF := 0xAA
+  v2 := 50
   v2 <<= v2 # 100 (0x64)
   expect-v2-vf-v3 100 0 0
 
@@ -172,69 +179,72 @@
   text 0 16 flags-carry
   x := 22
   y := 16
-
-  v0 := 200
-  v1 := 100
+  100_in_a_register := 100
 
   # Addition (with overflow)
   opcode-digit 0x4 # 0x84
-  v3 := 200
-  vF := 100
-  vF += v3 # 300 (0x2C), but should be overwritten by flag, so 1
+  vF := 200
+  vF += 100_in_a_register # 300 (0x2C), but should be overwritten by flag, so 1
   v4 := vF
-  vF := 100
+  v3 := 100
+  vF := 200
   v3 += vF # 300 (0x2C)
-  v2 := v0
-  v2 += v1 # 300 (0x2C)
-  expect-v2-vf-v3-v4 0x2C 1 0x2C 1
+  # vF := 0xAA
+  v2 := 200
+  v2 += 100_in_a_register # 300, but overflows so 44 (0x2C)
+  expect-v2-vf-v3-v4 44 1 44 1
   x += 1
 
   # Subtraction in one direction (with carry)
   opcode-digit 0x5 # 0x85
-  v3 := 15
-  vF := 10
-  vF -= v3 # -5 = 251 (0xFB), but should be overwritten by flag, so 0
+  vF := 95
+  vF -= 100_in_a_register # -5 = 251 (0xFB), but should be overwritten by flag, so 0
   v4 := vF
-  vF := 20
+  v3 := 95
+  vF := 100
   v3 -= vF # -5 = 251 (0xFB)
-  v2 := v1
-  v2 -= v0 # 100 - 200 = -100 = 156 (0x9C)
-  expect-v2-vf-v3-v4 0x9C 0 0xFB 0
+  vF := 0xAA
+  v2 := 95
+  v2 -= 100_in_a_register # -5 = 251 (0xFB)
+  expect-v2-vf-v3-v4 -5 0 -5 0
 
   y += 5
   x := 0
 
   # Shift right (with LSB)
   opcode-digit 0x6 # 0x86
-  vF := 27
-  vF >>= vF # 13 (0xD), but should be overwritten by flag, so 1
+  vF := 61
+  vF >>= vF # 30 (0x1E), but should be overwritten by flag, so 1
   v3 := vF
-  v2 := 27
-  v2 >>= v2 # 13 (0xD)
-  expect-v2-vf-v3 13 1 1
+  # vF := 0xAA
+  v2 := 61
+  v2 >>= v2 # 30 (0x1E)
+  expect-v2-vf-v3 30 1 1
   x += 5
 
   # Subtraction in the other direction (with carry)
   opcode-digit 0x7 # 0x87
-  v3 := 20
-  vF := 25
-  vF =- v3 # -5 = 251 (0xFB), but should be overwritten by flag, so 0
+  vF := 105
+  vF =- 100_in_a_register # -5 = 251 (0xFB), but should be overwritten by flag, so 0
   v4 := vF
-  vF := 15
+  v3 := 105
+  vF := 100
   v3 =- vF # -5 = 251 (0xFB)
-  v2 := v0
-  v2 =- v1 # 100 - 200 = -100 = 156 (0x9C)
-  expect-v2-vf-v3-v4 0x9C 0 0xFB 0
+  # vF := 0xAA
+  v2 := 105
+  v2 =- 100_in_a_register # -5 = 251 (0xFB)
+  expect-v2-vf-v3-v4 -5 0 -5 0
   x += 1
   
   # Shift left (with MSB)
   opcode-digit 0xE # 0x8E
-  vF := v0
-  vF <<= vF # 400 (0x90), but should be overwritten by flag, so 1
+  vF := 188
+  vF <<= vF # 376 (0x178), but should be overwritten by flag, so 1
   v3 := vF
-  v2 := v0
-  v2 <<= v2 # 400 (0x90)
-  expect-v2-vf-v3 0x90 1 1
+  # vF := 0xAA
+  v2 := 188
+  v2 <<= v2 # 376 (0x178), but overflows so 120 (0x78)
+  expect-v2-vf-v3 120 1 1
 
   # Addition to i
 
@@ -247,13 +257,22 @@
   opcode-digit 0xE # opcode 0xFE
 
   i := scratchpad
-  v1 := 0x10
+  v1 := 16
   i += v1
   v0 := 0xAA
   save v0
   i := scratchpad-plus-16
   load v0
   expect-v0 0xAA
+
+  # i := scratchpad
+  # vF := 16
+  # i += vF
+  # v0 := 0x55
+  # save v0
+  # i := scratchpad-plus-16
+  # load v0
+  # expect-v0 0x55
 
   jump menu-after-keypress
 


### PR DESCRIPTION
Makes the flags test a bit more readable, I think. And I believe there was an edge case where someone had a faulty implementation that was still "valid" according to the test that started all of this madness... should've documented and finished that when I still knew what it was I guess 😂

Also, this resets vF before every test and adds a test for `i += vF`. Much of that is still commented out though because of space constraints...