### PR TITLE
Keypad test: More info on `NOT HALTING`

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,8 @@ Otherwise, you can get either of these errors:
 
 * `NOT HALTING` - Your implementation immediately returns the value of any
   currently pressed keys in `vX`, instead of halting the interpreter until a key
-  is pressed (note that this needs timer support to be accurate)
+  is pressed (note that this needs timer support to be accurate - in other words,
+  the DELAY TIMER should continue to count down while awaiting a keypress)
 * `NOT RELEASED` - Your implementation doesn't wait for the pressed key to be
   released before resuming
 


### PR DESCRIPTION
My test wasn't passing because the interpreter didn't count down the delay timer while waiting for keypress - add a note here for others, so they don't encounter the same problem.